### PR TITLE
update changelog and add composer install

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,10 +2,12 @@ turnkey-typo3-14.1 (1) turnkey; urgency=low
 
   * Changed visible references of 'Typo3' to 'TYPO3' [#463].
 
+  * Latest upstream TYPO3 now installed via Composer [#464].
+
   * Note: Please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.
 
- -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 18 Feb 2016 16:42:02 +1100
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Mon, 22 Feb 2016 16:07:02 +1100
 
 turnkey-typo3-14.0 (1) turnkey; urgency=low
 

--- a/conf.d/composer
+++ b/conf.d/composer
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+curl -sS https://getcomposer.org/installer | php -- --filename='composer' --install-dir='/usr/local/bin'


### PR DESCRIPTION
The composer installer will move to common in v14.2 but for v14.1 build it is required.
