### PR TITLE
Build fix

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -54,7 +54,7 @@ cp web/typo3conf/ext/typo3_console/Scripts/typo3cms .
 chmod +x typo3cms
 ./typo3cms install:setup --non-interactive TRUE --database-user-name "$DB_USER" --database-user-password "$DB_PASS" --database-host-name localhost --database-name "$DB_NAME" --database-create FALSE --admin-user-name "$ADMIN_NAME" --admin-password "$ADMIN_PASS" --site-name "TurnKey TYPO3"
 ./typo3cms database:updateschema '*.*'
-./typo3cms extension:install realurl
+./typo3cms extension:install realurl || true
 ./typo3cms extension:install bootstrap_package
 ./typo3cms extension:install introduction
 


### PR DESCRIPTION
Appears to work fine without realurl. When the problem is resolved upstream, realurl will be installed again.
